### PR TITLE
Accept a REPOSITORY_NAME environment variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,10 @@ import requests
 
 
 def main():
-    repo_name = os.environ["GITHUB_REPOSITORY"]
+    if "REPOSITORY_NAME" in os.environ:
+        repo_name = os.environ["REPOSITORY_NAME"]
+    else:
+        repo_name = os.environ["GITHUB_REPOSITORY"]
     repo_stats = RepoStats(
         repo_name, os.environ["TRAFFIC_ACTION_TOKEN"])
 


### PR DESCRIPTION
Main.py can accept a `REPOSITORY_NAME` env variable when this is defined in the `workflow.yml` file:
```yaml
    steps:
    # Calculates traffic and clones and stores in CSV file
    - name: Repository Traffic 
      uses: sangonzal/repository-traffic-action@v0.1.5
      env:
        TRAFFIC_ACTION_TOKEN: ${{ secrets.TRAFFIC_ACTION_TOKEN }}
        REPOSITORY_NAME: <org>/<repository>
```

When not, it uses the `GITHUB_REPOSITORY` env.